### PR TITLE
Fixed bugs which occur in python3.

### DIFF
--- a/autoload/vimbufsync.py
+++ b/autoload/vimbufsync.py
@@ -33,7 +33,7 @@ version = [0,1,0] # 0.1.0
 def check_version(v,who="a plugin"):
   """Call it with required version number to print error message if needed"""
   global version
-  if isinstance(v,str): v = map(int,v.split("."))
+  if isinstance(v,str): v = list(map(int,v.split(".")))
   if v > version:
     msg = "vimbufsync: current version is %s but %s requires version %s (installed in \"%s\"). Please update."
     sys.stderr.write(msg % (".".join(map(str,version)), who, ".".join(map(str,v)), os.path.abspath(__file__)))


### PR DESCRIPTION
In python3, "map" function does not return list but it return map object.
This problem is easily solved by replacing map() with list(map()).
This correction is compatible with python2.